### PR TITLE
Bump Guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.1",
+        "guzzlehttp/guzzle": "~6.2",
         "guzzlehttp/oauth-subscriber": "0.3.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.2.1",
+        "guzzlehttp/guzzle": "~6.2",
         "guzzlehttp/oauth-subscriber": "0.3.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.2",
+        "guzzlehttp/guzzle": "~6.2.1",
         "guzzlehttp/oauth-subscriber": "0.3.*"
     },
     "require-dev": {


### PR DESCRIPTION
Bump minimum Guzzle version to 6.2.1 to address the httpoxy issue.

See https://github.com/guzzle/guzzle/releases/tag/6.2.1 for more details.