### PR TITLE
Update required PHP and dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 sudo: false
 php:
-  - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
 before_install:
     - composer self-update
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The intention of this class is to allow PHP application developers quick and eas
 
 ## Requirements
 
-* PHP >= 5.5.0,
+* PHP >= 5.6.0,
 * [Guzzle 6](https://github.com/guzzle/guzzle) library and the [Guzzle OAuth1 Subscriber](https://github.com/guzzle/oauth-subscriber),
 * (optional) [PHPUnit](https://phpunit.de/) and [php-cs-fixer](http://cs.sensiolabs.org/) to run tests.
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "guzzlehttp/oauth-subscriber": "0.3.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "friendsofphp/php-cs-fixer": "~1.11",
+        "phpunit/phpunit": "~5.0",
+        "friendsofphp/php-cs-fixer": "~2.12",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "guzzlehttp/guzzle": "~6.2",
         "guzzlehttp/oauth-subscriber": "0.3.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "friendsofphp/php-cs-fixer": "~1.11",
-        "satooshi/php-coveralls": "dev-master"
+        "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
         "psr-4": { "phpSmug\\": "lib/phpSmug/" }

--- a/examples/example-external-links.php
+++ b/examples/example-external-links.php
@@ -66,7 +66,8 @@ try {
 
         // Step 2: Get the User to login to SmugMug and authorise this demo
         echo '<p>Click <a href="'.$client->getAuthorizeURL().'"><strong>HERE</strong></a> to Authorize This Demo.</p>';
-        // Alternatively, automatically direct your visitor by commenting out the above line in favour of this:
+
+    // Alternatively, automatically direct your visitor by commenting out the above line in favour of this:
         //header("Location:".$client->getAuthorizeURL());
     } else {
         $reqToken = unserialize($_SESSION['SmugGalReqToken']);

--- a/examples/example-oauth.php
+++ b/examples/example-oauth.php
@@ -62,7 +62,7 @@ try {
 
         // Step 2: Get the User to login to SmugMug and authorise this demo
         echo '<p>Click <a href="'.$client->getAuthorizeURL().'"><strong>HERE</strong></a> to Authorize This Demo.</p>';
-        // Alternatively, automatically direct your visitor by commenting out the above line in favour of this:
+    // Alternatively, automatically direct your visitor by commenting out the above line in favour of this:
         //header("Location:".$client->getAuthorizeURL());
     } else {
         $reqToken = unserialize($_SESSION['SmugGalReqToken']);

--- a/test/phpSmug/Tests/PsrComplianceTest.php
+++ b/test/phpSmug/Tests/PsrComplianceTest.php
@@ -23,7 +23,7 @@ class PsrComplianceTest extends \PHPUnit_Framework_TestCase
 
         // Run linter in dry-run mode so it changes nothing.
         exec(
-            escapeshellcmd('vendor/bin/php-cs-fixer fix --diff -v --dry-run .').' 2>&1',
+            escapeshellcmd('vendor/bin/php-cs-fixer fix --diff -v --dry-run --using-cache=no .').' 2>&1',
             $output,
             $return_var
         );


### PR DESCRIPTION
Things have moved on quite a bit since the last release of phpSmug so it's time to update the minimum requirements.

The new minimum required version of PHP is 5.6. This will change to 7.1 from January 2019 as both 5.6 and 7.0 will be out of security update support and really shouldn't be used anymore (ref http://php.net/supported-versions.php).

This PR also switches out the deprecated satooshi/php-coveralls for php-coveralls/php-coveralls.