### PR TITLE
Add support for "non-inline" expansions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,7 +123,6 @@ $client->get('/api/v2/user/username1,username2?_filteruri=UserProfile');
 
 The filters and expansions can also be passed in the `$options` instead if you prefer.
 
-
 **The GET $options - Optional**
 
 When querying the SmugMug API, you can optionally limit or increase the information SmugMug returns by passing additional optional options to each query.  In the case of `_verbosity` and `_shorturis`, these options overrule those set when instantiating the client.
@@ -141,7 +140,6 @@ $options = [
 $client->get('user/username!profile', $options);
 ```
 
-`$options` can't use used for any SmugMug option that starts with an exclamation mark, like `!profile`.  In these cases, you need to include this option in the `$object` path.
 
 ### Making Changes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,6 +140,7 @@ $options = [
 $client->get('user/username!profile', $options);
 ```
 
+If you use the `_expand` option, without setting `_expandmethod` to `inline`, SmugMug returns the expansions in their own object indexed by the expanded URI. To make things easier, phpSmug appends this object to the response object.
 
 ### Making Changes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,7 +140,7 @@ $options = [
 $client->get('user/username!profile', $options);
 ```
 
-If you use the `_expand` option, without setting `_expandmethod` to `inline`, SmugMug returns the expansions in their own object indexed by the expanded URI. To make things easier, phpSmug appends this object to the response object.
+If you use the `_expand` option without setting `_expandmethod` to `inline`, SmugMug returns the expansions in their own object indexed by the expanded URI. To make things easier, phpSmug appends this object to the response object.
 
 ### Making Changes
 

--- a/lib/phpSmug/Client.php
+++ b/lib/phpSmug/Client.php
@@ -178,7 +178,11 @@ class Client
     {
         $o = [];
         foreach ($optimizers as $key => $value) {
-            $o[$key] = (is_array($value)) ? implode(',', $value) : $value;
+            if ($key == '_config' && is_array($value)) {
+                $o[$key] = json_encode($value);
+            } else {
+                $o[$key] = (is_array($value)) ? implode(',', $value) : $value;
+            }
         }
 
         return $o;

--- a/lib/phpSmug/Client.php
+++ b/lib/phpSmug/Client.php
@@ -178,11 +178,7 @@ class Client
     {
         $o = [];
         foreach ($optimizers as $key => $value) {
-            if ($key == '_config' && is_array($value)) {
-                $o[$key] = json_encode($value);
-            } else {
-                $o[$key] = (is_array($value)) ? implode(',', $value) : $value;
-            }
+            $o[$key] = (is_array($value)) ? implode(',', $value) : $value;
         }
 
         return $o;

--- a/lib/phpSmug/Client.php
+++ b/lib/phpSmug/Client.php
@@ -348,6 +348,10 @@ class Client
           default:
               $body = json_decode((string) $this->response->getBody());
               if (isset($body->Response)) {
+                  if (isset($body->Expansions)) {
+                      $body->Response->Expansions = $body->Expansions;
+                  }
+
                   return $body->Response;
               } else {
                   return $body;

--- a/test/phpSmug/Tests/ClientTest.php
+++ b/test/phpSmug/Tests/ClientTest.php
@@ -21,7 +21,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->OAuthSecret = 'I-am-not-a-valid-OAuthSecret-but-it-does-not-matter-for-this-test';
         $this->oauth_token = 'I-am-an-oauth-token';
         $this->oauth_token_secret = 'I-am-an-oauth-token-secret';
-        $this->fauxSmugMugResponse = '{"Options":{"foo":"bar"},"Response": {"ano":"bar"},"Code":200,"Message":"OK"}';
+        $this->fauxSmugMugResponse = '{"Options":{"foo":"bar"},"Response": {"ano":"bar"},"Code":200,"Message":"OK","Expansions": {"foo":"bar"}}';
         $this->fauxRequestTokenResponse = "oauth_token={$this->oauth_token}&oauth_token_secret={$this->oauth_token_secret}&oauth_callback_confirmed=true";
         $this->fauxAccessTokenResponse = "oauth_token={$this->oauth_token}&oauth_token_secret={$this->oauth_token_secret}";
         $this->fauxDeleteResponse = '{"Response":{"Uri":"/api/v2/album/rAnD0m","Locator":"Album","LocatorType":"Object"},"Code":200,"Message":"Ok"}';
@@ -257,7 +257,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $response = $client->get('user/'.$this->user);
 
         $this->assertObjectHasAttribute('ano', $response);
+        $this->assertObjectHasAttribute('Expansions', $response);
         $this->assertEquals('bar', $response->ano);
+        $this->assertEquals('bar', $response->Expansions->foo);
     }
 
     /**


### PR DESCRIPTION
If you use the `_expand` option without setting `_expandmethod` to `inline`, SmugMug returns the expansions in their own object indexed by the expanded URI. As you can see from the example on the [expansions documentation page](https://api.smugmug.com/api/v2/doc/advanced/expansions.html), this is outside of the `Response` object.

This PR makes those expansions accessible by appending the `Expansions` object in the SmugMug response to the `Response` object so they can be accessed using `$response->Expansions->foo`.

Fixes https://github.com/lildude/phpSmug/issues/47