### PR TITLE
JSON encode the `_config` option for ease of use

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,6 +143,8 @@ $client->get('user/username!profile', $options);
 
 `$options` can't use used for any SmugMug option that starts with an exclamation mark, like `!profile`.  In these cases, you need to include this option in the `$object` path.
 
+You can configure expansions using the `_config` option. You can pass this to phpSmug as part of the `$options` array as an array or JSON encoded string. If an array is received, phpSmug will JSON encode it for you else it'll assume it has already been JSON encoded.
+
 ### Making Changes
 
 All changes to objects on SmugMug need to be made using the `POST`, `PUT`, `PATCH` or `DELETE` HTTP methods and you can do so as follows:

--- a/lib/phpSmug/Client.php
+++ b/lib/phpSmug/Client.php
@@ -178,7 +178,11 @@ class Client
     {
         $o = [];
         foreach ($optimizers as $key => $value) {
-            $o[$key] = (is_array($value)) ? implode(',', $value) : $value;
+            if ($key == '_config' && is_array($value)) {
+                $o[$key] = json_encode($value);
+            } else {
+                $o[$key] = (is_array($value)) ? implode(',', $value) : $value;
+            }
         }
 
         return $o;

--- a/test/phpSmug/Tests/ClientTest.php
+++ b/test/phpSmug/Tests/ClientTest.php
@@ -227,7 +227,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $handler = HandlerStack::create($mock);
         $client = new Client($this->APIKey, ['handler' => $handler]);
         $options = [
-            '_filter' => ['BioText', 'CoverImage'],  // TODO: Ensure default options are over-written and none are lost.
+            '_filter' => ['BioText', 'CoverImage'],
             '_filteruri' => ['User'],
             '_shorturis' => true,
             '_verbosity' => 2,
@@ -240,6 +240,75 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $this->assertArrayHasKey($key, $request_options['query']);
             $this->assertEquals((is_array($value)) ? implode(',', $value) : $value, $request_options['query'][$key]);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function shouldEncodeConfigOption()
+    {
+        $mock = new MockHandler([
+            new Response(200), // We don't care about headers or body for this test so we don't set them.
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client($this->APIKey, ['handler' => $handler]);
+        $options = [
+            '_verbosity' => 1,
+            '_config' => [
+                'filter' => ['NickName'],
+                'filteruri' => ['UserProfile'],
+                'expand' => [
+                    'UserProfile' => [
+                        'filter' => ['BioText'],
+                        'filteruri' => ['BioImage'],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $client->get('user/'.$this->user, $options);
+        $request_options = $client->getRequestOptions();
+
+        $this->assertArrayHasKey('_config', $request_options['query']);
+        $this->assertEquals('{"filter":["NickName"],"filteruri":["UserProfile"],"expand":{"UserProfile":{"filter":["BioText"],"filteruri":["BioImage"]}}}', $request_options['query']['_config']);
+        json_decode($request_options['query']['_config']);
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotDoubleEncodeEncodedConfigOption()
+    {
+        $mock = new MockHandler([
+            new Response(200), // We don't care about headers or body for this test so we don't set them.
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client($this->APIKey, ['handler' => $handler]);
+        $config = [
+            'filter' => ['NickName'],
+            'filteruri' => ['UserProfile'],
+            'expand' => [
+                'UserProfile' => [
+                    'filter' => ['BioText'],
+                    'filteruri' => ['BioImage'],
+                ],
+            ],
+        ];
+        $options = [
+            '_verbosity' => 1,
+            '_config' => json_encode($config),
+        ];
+
+        $response = $client->get('user/'.$this->user, $options);
+        $request_options = $client->getRequestOptions();
+
+        $this->assertArrayHasKey('_config', $request_options['query']);
+        $this->assertEquals('{"filter":["NickName"],"filteruri":["UserProfile"],"expand":{"UserProfile":{"filter":["BioText"],"filteruri":["BioImage"]}}}', $request_options['query']['_config']);
+        json_decode($request_options['query']['_config']);
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
     }
 
     /**


### PR DESCRIPTION
As suggested in https://github.com/lildude/phpSmug/issues/49, it would be nice if phpSmug JSON encoded the `_config` option if provided as an array. This PR implements just that.

If an array is received for `_config` it is JSON encoded for you. If a string is received, it is assumed you have already JSON encoded the configuration.

Fixes https://github.com/lildude/phpSmug/issues/49