### PR TITLE
Strip empty args from url

### DIFF
--- a/lib/phpSmug/Client.php
+++ b/lib/phpSmug/Client.php
@@ -134,6 +134,8 @@ class Client
         // Cater for any args passed in via `?whatever=foo`
         if (strpos($url, '?') !== false) {
             $pairs = explode('&', explode('?', $url)[1]);
+            // remove empty args caused by adjacent &s in $url
+            $pairs = array_diff($pairs, ['']);
             foreach ($pairs as $pair) {
                 list($key, $value) = explode('=', $pair);
                 $this->request_options['query'][$key] = $value;

--- a/test/phpSmug/Tests/ClientTest.php
+++ b/test/phpSmug/Tests/ClientTest.php
@@ -218,6 +218,23 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldStripOutEmptyQueryArgs()
+    {
+        $mock = new MockHandler([
+            new Response(200), // We don't care about headers or body for this test so we don't set them.
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client($this->APIKey, ['handler' => $handler]);
+        $response = $client->get('user/'.$this->user.'?_expand=UserProfile&&_verbosity=2');
+        // We don't really need this assertion as the phpunit config `convertNoticesToExceptions="true"`
+        // means this test will fail before now, but it's nice to have an assertion to be sure.
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @test
+     */
     public function shouldSetQueryFromOptionsPassedOnRequestAndOverWriteDefaults()
     {
         $mock = new MockHandler([


### PR DESCRIPTION
From https://github.com/lildude/phpSmug/issues/43

> When certain unusual URI queries are passed to phpSmug, we sometimes receive the following error:
>
>> PHP Notice: Undefined offset: 1 in /vendor/lildude/phpsmug/lib/phpSmug/Client.php on line 139
>
>This is caused when contiguous '&' characters appear in the query statement, effectively creating empty arguments, as seen here between arg1 and arg2:
>
>>...?arg1=value1&&arg2=value2

This PR addresses this by stripping out empty arguments as suggested in that issue.

Fixes https://github.com/lildude/phpSmug/issues/43