### PR TITLE
Updating guzzle dependancy to fix a dependancy collision issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "guzzlehttp/guzzle": "~6.2",
+        "guzzlehttp/guzzle": "~6.5.5",
         "guzzlehttp/oauth-subscriber": "0.3.*"
     },
     "require-dev": {


### PR DESCRIPTION
The package smugmug-embed leverages your package, but the guzzle 6.2 dependency is causing a dependency collision by updating to the newer 6.5.5 version, the issue is resolved.