### PR TITLE
Move oauth middleware

### DIFF
--- a/lib/phpSmug/Client.php
+++ b/lib/phpSmug/Client.php
@@ -309,7 +309,7 @@ class Client
 
             $oauth_middleware = new \GuzzleHttp\Subscriber\Oauth\Oauth1($oauth_middleware_config);
 
-            $this->stack->unshift($oauth_middleware, 'oauth_middleware'); // Bump OAuth to the bottom of the stack
+            $this->stack->after('allow_redirects', $oauth_middleware, 'oauth_middleware'); // Bump OAuth to the bottom of the stack
         }
 
         // Merge the default and request options for all requests except upload requests.


### PR DESCRIPTION
Move oauth middleware after redirects middleware so redirect also gets new oauth token

This fixes issue at https://github.com/lildude/phpSmug/issues/68
We are experiencing the same issue. If the response indicates a redirect, the redirect results in a 401 because the same nonce is being used.