### PR TITLE
Update CI PHP versions to 8.1 - 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.3', '7.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,6 @@ jobs:
       run: composer update --prefer-dist
 
     - name: Run tests
+      if: ${{matrix.php}} == '8.1'
+      run: vendor/bin/phpunit --configuration phpunit-8.1.xml
       run: vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,3 @@ jobs:
 
     - name: Run tests
       run: vendor/bin/phpunit
-
-    - name: Upload coverage results to Coveralls
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: vendor/bin/php-coveralls --coverage_clover=build/logs/clover.xml -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
       run: composer update --prefer-dist
 
     - name: Run tests
-      if: ${{matrix.php}} == '8.1'
-      run: vendor/bin/phpunit --configuration phpunit-8.1.xml
-      if: ${{matrix.php}} != '8.1'
-      run: vendor/bin/phpunit
+      run: |
+        if [ ${{ matrix.php }} == '8.1' ]; then
+          vendor/bin/phpunit --configuration phpunit-8.1.xml
+        else
+          vendor/bin/phpunit
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Run Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,5 @@ jobs:
     - name: Run tests
       if: ${{matrix.php}} == '8.1'
       run: vendor/bin/phpunit --configuration phpunit-8.1.xml
+      if: ${{matrix.php}} != '8.1'
       run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,7 @@
         "guzzlehttp/oauth-subscriber": "0.6.*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">9.0",
-        "php-coveralls/php-coveralls": "^2.7",
-        "friendsofphp/php-cs-fixer": "^3.65"
+        "phpunit/phpunit": ">9.0"
     },
     "autoload": {
         "psr-4": { "phpSmug\\": "lib/phpSmug/" }

--- a/phpunit-8.1.xml
+++ b/phpunit-8.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="false"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="phpSmug Test Suite">
+            <directory>test/phpSmug/</directory>
+        </testsuite>
+    </testsuites>
+
+    <groups>
+        <exclude>
+            <group>functional</group>
+        </exclude>
+    </groups>
+
+    <source restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>


### PR DESCRIPTION
Various dependencies were updated to require a minimum of PHP 8.1 in https://github.com/lildude/phpSmug/pull/93 and this updates CI to match.

This also removes two abandoned and unused dependencies and code coverage.