### PR TITLE
Remove `$` from README.md codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The development of phpSmug takes place in my free time. If you find phpSmug usef
 The recommended method of installing phpSmug is using [Composer](http://getcomposer.org). If you have Composer installed, you can install phpSmug and all its dependencies from within your project directory:
 
 ```bash
-$ composer require lildude/phpsmug
+composer require lildude/phpsmug
 ```
 
 Alternatively, you can add the following to your project's `composer.json`:
@@ -46,7 +46,7 @@ Alternatively, you can add the following to your project's `composer.json`:
 If you don't have Composer installed, you can download it using:
 
 ```bash
-$ curl -s http://getcomposer.org/installer | php
+curl -s http://getcomposer.org/installer | php
 ```
 
 ## Basic Usage of the phpSmug Client


### PR DESCRIPTION
Remove `$` from codeblocks in the README.md so cut-and-paste works